### PR TITLE
Fix: append to kernel-local instead of overwriting it

### DIFF
--- a/kernel/kernel.sh
+++ b/kernel/kernel.sh
@@ -26,7 +26,7 @@ sed -i "/Patch1:/a Patch2: t2linux-combined.patch" "kernel.spec"
 sed -i "/ApplyOptionalPatch patch-%{patchversion}-redhat.patch/a ApplyOptionalPatch t2linux-combined.patch" "kernel.spec"
 
 cat "linux-t2-patches/extra_config" > "kernel-local"
-cat << 'EOF' > "kernel-local"
+cat << 'EOF' >> "kernel-local"
 CONFIG_SPI_HID_APPLE_OF=y
 CONFIG_HID_DOCKCHANNEL=y
 CONFIG_APPLE_DOCKCHANNEL=y


### PR DESCRIPTION
the cat command overwrote the extra_config from linux-t2-patches (the line above). Fixed by appending instead of overwriting.
Not sure if this was intentional or not, but looked like a bug.